### PR TITLE
Fix numpy warnings

### DIFF
--- a/evgraf/crystal_comparator.py
+++ b/evgraf/crystal_comparator.py
@@ -22,7 +22,7 @@ class CrystalComparator:
             self.barycenter = std.barycenter
 
     def _get_neighboring_cells(self):
-        pbc = self.atoms.pbc.astype(np.int)
+        pbc = self.atoms.pbc.astype(int)
         return np.array(list(itertools.product(*[range(-p, p + 1)
                                                  for p in pbc])))
 

--- a/evgraf/crystal_reduction.py
+++ b/evgraf/crystal_reduction.py
@@ -13,8 +13,8 @@ def assign_atoms_to_clusters(num_atoms, permutations):
     uf = DisjointSet(num_atoms)
     for p in permutations:
         for i, e in enumerate(p):
-            uf.merge(i, e)
-    return uf.get_components(relabel=True)
+            uf.union(i, e)
+    return uf.find_all(relabel=True)
 
 
 def reduction_basis(n, H, pbc):

--- a/evgraf/subgroup_enumeration.py
+++ b/evgraf/subgroup_enumeration.py
@@ -31,7 +31,7 @@ def get_subgroup_elements(orders, H):
             size *= x // e
 
     dimension = len(orders)
-    indices = np.zeros((size, dimension)).astype(np.int)
+    indices = np.zeros((size, dimension), dtype=int)
     indices[:, 0] = H[0, 0] * np.arange(size)
 
     for i, order in enumerate(orders):
@@ -46,7 +46,7 @@ def get_subgroup_elements(orders, H):
 
 def consistent_first_rows(dimension, dm, ffilter):
     for a in dm:
-        H = np.zeros((dimension, dimension)).astype(np.int)
+        H = np.zeros((dimension, dimension), dtype=int)
         H[0, 0] = a
         if ffilter is None or ffilter(H):
             yield a
@@ -131,7 +131,7 @@ def enumerate_subgroup_bases(orders, ffilter=None,
                 for t in range(A):
                     s = a * t // A
 
-                    H = np.zeros((dimension, dimension)).astype(np.int)
+                    H = np.zeros((dimension, dimension), dtype=int)
                     H[0] = [a, 0, 0]
                     H[1] = [s, b, 0]
                     H[2, 2] = r

--- a/evgraf/utils/minkowski_reduction.py
+++ b/evgraf/utils/minkowski_reduction.py
@@ -54,7 +54,7 @@ def closest_vector(t0, u, v):
 
 def reduction_full(B):
     """Calculate a Minkowski-reduced lattice basis (3D reduction)."""
-    H = np.eye(3).astype(np.int)
+    H = np.eye(3, dtype=int)
     norms = np.linalg.norm(B, axis=1)
 
     max_it = 100000    # in practice this is not exceeded
@@ -122,7 +122,7 @@ def minkowski_reduce(cell, pbc=True):
     pbc = pbc2pbc(pbc)
     dim = pbc.sum()
 
-    op = np.eye(3).astype(np.int)
+    op = np.eye(3, dtype=int)
     if dim == 2:
         perm = np.argsort(pbc, kind='merge')[::-1]    # stable sort
         pcell = cell[perm][:, perm]

--- a/tests/minkowski_reduce.py
+++ b/tests/minkowski_reduce.py
@@ -28,7 +28,7 @@ def test_random_3D(seed):
 
     # Test idempotency
     _, _H = minkowski_reduce(R)
-    assert (_H == np.eye(3).astype(np.int)).all()
+    assert (_H == np.eye(3, dtype=int)).all()
 
     rcell, _ = minkowski_reduce(B)
     assert np.allclose(rcell, R, atol=tol)
@@ -71,10 +71,10 @@ def test_single_vector():
 @pytest.mark.parametrize("i", range(3))
 def test_2D(i):
     pbc = np.roll([0, 1, 1], i)
-    rcell, op = minkowski_reduce(lcell.astype(np.float), pbc=pbc)
+    rcell, op = minkowski_reduce(lcell.astype(float), pbc=pbc)
     assert (rcell[i] == lcell[i]).all()
 
-    zcell = np.copy(lcell.astype(np.float))
+    zcell = np.copy(lcell.astype(float))
     zcell[i] = 0
     rzcell, _ = minkowski_reduce(zcell, zcell.any(1))
     rcell[i] = 0


### PR DESCRIPTION
np.int and np.float are deprecated aliases of built-in int and float.

Update code accordingly.

I now no longer get any warnings from the test suite.

This PR includes the commit from #8, since I didn't want to apply fixes to a failing test suite.